### PR TITLE
setup: fix environment classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ author = Derrick J Wippler
 author-email = thrawn01@gmail.com
 home-page = https://github.com/rackerlabs/python-lunrclient
 classifier =
-    Environment :: Lunr
+    Environment :: Other Environment
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License


### PR DESCRIPTION
https://pypi.python.org/pypi?%3Aaction=list_classifiers

It doesn't look like there's much precident for making a new environment for every arbitrary thing, so I guess I won't even try. This changes the `Environment` classifier to something actually valid, so that `lunrclient` can actually be uploaded to pypi.